### PR TITLE
Added support for TESTFUZN_TAGS_FILTER_INCLUDE/EXCLUDE

### DIFF
--- a/src/SampleApp.WebApp/Program.cs
+++ b/src/SampleApp.WebApp/Program.cs
@@ -1,4 +1,5 @@
-﻿using SampleApp.WebApp.WebSockets;
+﻿using SampleApp.WebApp.Models;
+using SampleApp.WebApp.WebSockets;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,6 +23,24 @@ builder.Services.AddTransient<ProductService>();
 builder.Services.AddSingleton<WebSocketHandler>();
 
 var app = builder.Build();
+
+// Seed initial products (only if empty to avoid duplicates on hot reload, etc.)
+var productService = app.Services.GetRequiredService<ProductService>();
+var existing = await productService.GetAllProducts();
+if (existing.Count == 0)
+{
+    var initialProducts = new[]
+    {
+        new Product { Id = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Name = "Alpha",   Price = 10.99m },
+        new Product { Id = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), Name = "Bravo",   Price = 15.50m },
+        new Product { Id = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"), Name = "Charlie", Price = 8.25m },
+        new Product { Id = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"), Name = "Delta",   Price = 22.10m },
+        new Product { Id = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"), Name = "Echo",    Price = 5.75m }
+    };
+
+    foreach (var p in initialProducts)
+        productService.AddProduct(p);
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/src/TestFuzn.Adapters.MSTest/BaseFeatureTest.cs
+++ b/src/TestFuzn.Adapters.MSTest/BaseFeatureTest.cs
@@ -56,7 +56,6 @@ public abstract class BaseFeatureTest : IFeatureTest
         return scenario;
     }
 
-
     private void EnsureTestMethodIsNotUsed(MethodInfo methodInfo)
     {
         // Check for MSTest [TestMethod] attribute

--- a/src/TestFuzn.Adapters.MSTest/MsTestAdapter.cs
+++ b/src/TestFuzn.Adapters.MSTest/MsTestAdapter.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Fuzn.TestFuzn.ConsoleOutput;
 using Fuzn.TestFuzn.Contracts.Adapters;
 using Fuzn.TestFuzn.Contracts.Results.Load;

--- a/src/TestFuzn.Adapters.MSTest/MsTestContext.cs
+++ b/src/TestFuzn.Adapters.MSTest/MsTestContext.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections;
-
-namespace Fuzn.TestFuzn;
+﻿namespace Fuzn.TestFuzn;
 
 public class MsTestContext : TestContext
 {

--- a/src/TestFuzn.Adapters.MSTest/ScenarioTestAttribute.cs
+++ b/src/TestFuzn.Adapters.MSTest/ScenarioTestAttribute.cs
@@ -1,4 +1,6 @@
-﻿namespace Fuzn.TestFuzn;
+﻿using System.Reflection;
+
+namespace Fuzn.TestFuzn;
 
 [AttributeUsage(AttributeTargets.Method)]
 public class ScenarioTestAttribute : TestMethodAttribute
@@ -12,6 +14,69 @@ public class ScenarioTestAttribute : TestMethodAttribute
 
     public override async Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
     {
+        if (string.IsNullOrEmpty(testMethod.TestMethodName))
+            throw new Exception("TestContext.TestName is null or empty.");
+
+        List<TestCategoryAttribute> tagsAttributes = testMethod.MethodInfo.GetCustomAttributes(typeof(TestCategoryAttribute), inherit: true)
+                                       .OfType<TestCategoryAttribute>()
+                                       .ToList();
+
+        if (tagsAttributes.Count > 0)
+        {
+            var tags = tagsAttributes
+                .SelectMany(a => a.TestCategories ?? [])
+                .Where(c => !string.IsNullOrWhiteSpace(c))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (tags.Count > 0)
+            {
+                if (GlobalState.TagsFilterInclude.Count > 0)
+                {
+                    if (!tags.Any(t => GlobalState.TagsFilterInclude.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                    {
+                        return
+                        [
+                            new TestResult
+                            {
+                                Outcome = UnitTestOutcome.Inconclusive,
+                                TestFailureException = new Exception($"ScenarioTest skipped due to missing include tags. Test tags: [{string.Join(", ", tags)}], Include tags: [{string.Join(", ", GlobalState.TagsFilterInclude)}]")
+                            }
+                        ];
+                    }
+                }
+
+                if (GlobalState.TagsFilterExclude.Count > 0)
+                {
+                    if (tags.Any(t => GlobalState.TagsFilterExclude.Contains(t, StringComparer.OrdinalIgnoreCase)))
+                    {
+                        return
+                        [
+                            new TestResult
+                            {
+                                Outcome = UnitTestOutcome.Inconclusive,
+                                TestFailureException = new Exception($"ScenarioTest skipped due to matching exclude tags. Test tags: [{string.Join(", ", tags)}], Exclude tags: [{string.Join(", ", GlobalState.TagsFilterExclude)}]")
+                            }
+                        ];
+                    }
+                }
+            }
+        }
+        else
+        {
+            if (GlobalState.TagsFilterInclude.Count > 0)
+            {
+                return
+                [
+                    new TestResult
+                    {
+                        Outcome = UnitTestOutcome.Inconclusive,
+                        TestFailureException = new Exception($"Test skipped due to missing include tags. ScenarioTest has no tags, Include tags: [{string.Join(", ", GlobalState.TagsFilterInclude)}]")
+                    }
+                ];
+            }
+        }
+
         var result = await base.ExecuteAsync(testMethod);
         return result;
     }

--- a/src/TestFuzn.Tests/.runsettings
+++ b/src/TestFuzn.Tests/.runsettings
@@ -3,6 +3,8 @@
   <RunConfiguration>
     <EnvironmentVariables>
 		<TESTFUZN_ENVIRONMENT></TESTFUZN_ENVIRONMENT>
+		<TESTFUZN_TAGS_FILTER_INCLUDE></TESTFUZN_TAGS_FILTER_INCLUDE>
+		<TESTFUZN_TAGS_FILTER_EXCLUDE></TESTFUZN_TAGS_FILTER_EXCLUDE>
     </EnvironmentVariables>
   </RunConfiguration>
 </RunSettings>

--- a/src/TestFuzn.Tests/FeatureSyntaxTests.cs
+++ b/src/TestFuzn.Tests/FeatureSyntaxTests.cs
@@ -21,8 +21,9 @@ public class SyntaxTests : BaseFeatureTest
     }
 
     [ScenarioTest(ScenarioRunMode.Skip)]
-    [TestCategory("Component")]
-    [TestCategory("E2E")]
+    [TestCategory("Category1")]
+    [TestCategory("Category2")]
+    [Environments("test")]
     public async Task DefaultContext()
     {
         // Definition of test types:

--- a/src/TestFuzn.Tests/Reports/FeatureReportTests.cs
+++ b/src/TestFuzn.Tests/Reports/FeatureReportTests.cs
@@ -4,10 +4,12 @@
 public class FeatureReportTests : BaseFeatureTest
 {
     [ScenarioTest]
+    [TestCategory("Category1")]
+    [TestCategory("Category2")]
+    [TestCategory("Category3")]
     public async Task Feature1()
     {
         await Scenario()
-            .Tags("Tag1", "Tag2", "Tag3")
             .Id("ID-1234")
             .InputData("user1", "user2", "user")
             .Metadata("ScenarioKey1", "Value1")

--- a/src/TestFuzn.Tests/Reports/LoadReportTests.cs
+++ b/src/TestFuzn.Tests/Reports/LoadReportTests.cs
@@ -11,10 +11,12 @@ public class LoadReportTests : BaseFeatureTest
     public override Dictionary<string, string> FeatureMetadata { get => new Dictionary<string, string>() { { "Meta1", "Value1" } }; }
 
     [ScenarioTest]
+    [TestCategory("Category1")]
+    [TestCategory("Category2")]
+    [TestCategory("Category3")]
     public async Task ShortRunning_NoErrors()
     {
         await Scenario()
-            .Tags("Tag1", "Tag2", "Tag3")
             .Id("ID-1234")
             .Metadata("MetadataScenarioKey1", "Value1")
             .Metadata("MetadataScenarioKey2", "Value2")

--- a/src/TestFuzn.Tests/Steps/SubStepsTests.cs
+++ b/src/TestFuzn.Tests/Steps/SubStepsTests.cs
@@ -48,11 +48,12 @@ public class SubStepsTests : BaseFeatureTest
     }
 
     [ScenarioTest]
+    [TestCategory("Category1")]
+    [TestCategory("Category2")]
     public async Task SubSteps_Async()
     {
         await Scenario()
             .Tags("CategoryA", "CategoryB")
-            .InputData("Testdata1", "Testdata2")
             .Step("Step 1", async (context) =>
             {
                 Assert.AreEqual("Step 1", context.StepInfo.Name);
@@ -96,10 +97,10 @@ public class SubStepsTests : BaseFeatureTest
     }
 
     [ScenarioTest]
+    [TestCategory("Category1")]
     public async Task SubSteps_Async_Load()
     {
         await Scenario()
-            .Tags("CategoryA")
             .Step("Step 1", async (context) =>
             {
                 Assert.AreEqual("Step 1", context.StepInfo.Name);

--- a/src/TestFuzn.Tests/Tags/TagsTests.cs
+++ b/src/TestFuzn.Tests/Tags/TagsTests.cs
@@ -5,8 +5,10 @@ public class TagsTests : BaseFeatureTest
 {
     public override string FeatureName => "";
 
-    [ScenarioTest]
     [TestCategory("Category1")]
+    [TestCategory("Category2")]
+    [TestCategory("Category3")]
+    [ScenarioTest]
     public async Task VerifySingleTestCategoryIsTurnedIntoTag()
     {
         await Scenario()
@@ -25,6 +27,7 @@ public class TagsTests : BaseFeatureTest
     [ScenarioTest]
     [TestCategory("Category1")]
     [TestCategory("Category2")]
+    [TestCategory("Category3")]
     public async Task VerifyMultipleTestCategoriesAreTurnedIntoTags()
     {
         await Scenario()
@@ -37,45 +40,6 @@ public class TagsTests : BaseFeatureTest
                 var tags = state.SharedExecutionState.Scenarios.First().TagsInternal;
                 Assert.Contains("Category1", tags);
                 Assert.Contains("Category2", tags);
-            })
-            .Run();
-    }
-
-    [ScenarioTest]
-    [TestCategory("Category1")]
-    public async Task VerifyTestCategoriesAndSpecifiedTagsArePartsOfTags()
-    {
-        await Scenario()
-            .Tags("Tag1")
-            .Step("Step 1", async (context) =>
-            {
-                await Task.CompletedTask;
-            })
-            .AssertInternalState(state => 
-            {
-                var tags = state.SharedExecutionState.Scenarios.First().TagsInternal;
-                Assert.Contains("Category1", tags);
-                Assert.Contains("Tag1", tags);
-            })
-            .Run();
-    }
-
-    [ScenarioTest]
-    public async Task VerifySpecifiedTags()
-    {
-        await Scenario()
-            .Tags("Tag1", "Tag2")
-            .Tags("Tag3")
-            .Step("Step 1", async (context) =>
-            {    
-                await Task.CompletedTask;
-            })
-            .AssertInternalState(state => 
-            {
-                var tags = state.SharedExecutionState.Scenarios.First().TagsInternal;
-                Assert.Contains("Tag1", tags);
-                Assert.Contains("Tag2", tags);
-                Assert.Contains("Tag3", tags);
             })
             .Run();
     }

--- a/src/TestFuzn/GlobalState.cs
+++ b/src/TestFuzn/GlobalState.cs
@@ -15,17 +15,9 @@ public static class GlobalState
     internal static DateTime TestRunStartTime { get; set; }
     internal static DateTime TestRunEndTime { get; set; }
     internal static TimeSpan SinkWriteFrequency { get; set; } = TimeSpan.FromSeconds(3);
-    internal static string NodeName { get; set; } = Environment.MachineName;
+    internal static string NodeName { get; set; }
     public static ISerializerProvider SerializerProvider => Configuration.SerializerProvider;
     public static string EnvironmentName { get; set; }
-
-    internal static void Init()
-    {
-        TestRunStartTime = DateTime.UtcNow;
-        DateTimeOffset test = DateTimeOffset.UtcNow;
-
-        TestRunId = $"{DateTime.Now:yyyy-MM-dd_HH-mm}__{Guid.NewGuid().ToString("N").Substring(0, 6)}";
-    
-        EnvironmentName = Environment.GetEnvironmentVariable("TESTFUZN_ENVIRONMENT") ?? "";
-    }
+    public static List<string> TagsFilterInclude { get; set; } = new();
+    public static List<string> TagsFilterExclude { get; set; } = new();
 }

--- a/src/TestFuzn/InternalsVisibleTo.cs
+++ b/src/TestFuzn/InternalsVisibleTo.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Fuzn.TestFuzn.Adapters.MSTest")]
 [assembly: InternalsVisibleTo("Fuzn.TestFuzn.Tests")]
 [assembly: InternalsVisibleTo("Fuzn.TestFuzn.Tests.Failing")]

--- a/src/TestFuzn/ScenarioBuilder.cs
+++ b/src/TestFuzn/ScenarioBuilder.cs
@@ -28,7 +28,7 @@ public class ScenarioBuilder<TModel>
         return this;
     }
 
-    public ScenarioBuilder<TModel> Environments(params string[] environments)
+    internal ScenarioBuilder<TModel> Environments(params string[] environments)
     {
         if (environments == null || environments.Length == 0)
             throw new ArgumentException("Environments cannot be null or empty.", nameof(environments));
@@ -39,7 +39,7 @@ public class ScenarioBuilder<TModel>
         return this;
     }
 
-    public ScenarioBuilder<TModel> Tags(params string[] tags)
+    internal ScenarioBuilder<TModel> Tags(params string[] tags)
     {
         if (tags == null || tags.Length == 0)
             throw new ArgumentException("Tags cannot be null or empty.", nameof(tags));


### PR DESCRIPTION
- Added support for TESTFUZN_TAGS_FILTER_INCLUDE and TESTFUZN_TAGS_FILTER_EXCLUDE in .runsettings
- Exposed via GlobalState
- Integrates with MSTest TestCategory ignoring logic
- #45 