### PR TITLE
feat(core): add AssertWhileWarmingUp and rate properties for load tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,5 @@ Test/sample projects: `TestFuzn.Tests`, `TestFuzn.Tests.Attributes`, `TestFuzn.T
   - **Strings:** `Assert.Contains`, `Assert.StartsWith`, `Assert.EndsWith`, `Assert.MatchesRegex` (prefer over `StringAssert`)
   - **Exceptions:** `Assert.ThrowsExactly<T>`, `Assert.ThrowsExactlyAsync<T>` (prefer over `[ExpectedException]`)
 - When making changes, update relevant README/documentation files (e.g. `README.md`, `docs/*.md`) if the change affects documented behavior, APIs, or usage examples
+- Test methods that are expected to throw an exception or fail should be prefixed with `ShouldFail_` (e.g. `ShouldFail_Verify_assert_while_running`)
+- Consistent terminology matters. Before naming new properties, classes, methods, or parameters, search the existing codebase to see what terms are already used for similar concepts. Use the same words -- e.g. if the codebase uses `Duration` for time spans, don't introduce `Elapsed` or `TimeSpan` for the same idea. This applies to naming at all levels: public API, internals, tests, and documentation.

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -109,6 +109,31 @@ No metrics or statistics are collected during the warmup phase, only the actual 
 })
 ```
 
+### Assert While Warming Up
+
+Validate warmup iterations and stop the test early if things are fundamentally broken (e.g., the target service is down). 
+Some failures during warmup are expected, so use conditions like minimum iteration count or elapsed time to avoid stopping prematurely:
+
+```csharp
+.Load().AssertWhileWarmingUp((context, warmup) =>
+{
+    // Stop if more than 80% of iterations fail after at least 10 have completed
+    if (warmup.TotalCount >= 10 && warmup.FailedRate > 0.8)
+        throw new Exception("Too many failures during warmup");
+})
+```
+
+Available properties on `WarmupStats`:
+
+| Property | Description |
+|----------|-------------|
+| `OkCount` | Number of successful warmup iterations |
+| `FailedCount` | Number of failed warmup iterations |
+| `TotalCount` | Total warmup iterations (OkCount + FailedCount) |
+| `OkRate` | Rate of successful iterations (0.0 to 1.0) |
+| `FailedRate` | Rate of failed iterations (0.0 to 1.0) |
+| `Duration` | Time since warmup started |
+
 ---
 
 ## Simulations
@@ -202,7 +227,13 @@ Chain multiple simulations together:
 
 ## Assertions
 
-Validate performance during and after test execution:
+Validate performance during and after test execution.
+
+All assertion methods follow the same pattern: if the action throws an exception, the test is stopped and marked as failed.
+
+### Assert While Warming Up
+
+See [Warmup > Assert While Warming Up](#assert-while-warming-up) above.
 
 ### Assert While Running
 
@@ -243,6 +274,8 @@ Available metrics for assertions:
 | Metric | Description |
 |--------|-------------|
 | `RequestCount` | Total number of requests |
+| `OkRate` | Rate of successful requests (0.0 to 1.0) |
+| `FailedRate` | Rate of failed requests (0.0 to 1.0) |
 | `RequestsPerSecond` | Requests per second |
 | `ResponseTimeMin` | Minimum response time |
 | `ResponseTimeMax` | Maximum response time |

--- a/src/TestFuzn.Tests/Assertions/AssertionTests.cs
+++ b/src/TestFuzn.Tests/Assertions/AssertionTests.cs
@@ -40,6 +40,60 @@ public class AssertionTests : Test
     }
 
     [Test]
+    public async Task Verify_ok_rate_and_failed_rate_all_ok()
+    {
+        await Scenario()
+            .Step("Step 1", (context) =>
+            {
+            })
+            .Load().Simulations((context, simulations) => simulations.OneTimeLoad(10))
+            .Load().AssertWhenDone((context, stats) =>
+            {
+                Assert.AreEqual(1.0, stats.OkRate);
+                Assert.AreEqual(0.0, stats.FailedRate);
+            })
+            .Run();
+    }
+
+    [Test]
+    public async Task Verify_ok_rate_and_failed_rate_all_failed()
+    {
+        await Scenario()
+            .Step("Step 1", (context) =>
+            {
+                Assert.Fail();
+            })
+            .Load().Simulations((context, simulations) => simulations.OneTimeLoad(10))
+            .Load().AssertWhenDone((context, stats) =>
+            {
+                Assert.AreEqual(0.0, stats.OkRate);
+                Assert.AreEqual(1.0, stats.FailedRate);
+            })
+            .Run();
+    }
+
+    [Test]
+    public async Task Verify_ok_rate_and_failed_rate_mixed()
+    {
+        var counter = 0;
+
+        await Scenario()
+            .Step("Step 1", (context) =>
+            {
+                var current = Interlocked.Increment(ref counter);
+                if (current % 2 == 0)
+                    Assert.Fail();
+            })
+            .Load().Simulations((context, simulations) => simulations.OneTimeLoad(10))
+            .Load().AssertWhenDone((context, stats) =>
+            {
+                Assert.AreEqual(0.5, stats.OkRate);
+                Assert.AreEqual(0.5, stats.FailedRate);
+            })
+            .Run();
+    }
+
+    [Test]
     public async Task Verify_assert_sub_steps_all_ok()
     {
         await Scenario()

--- a/src/TestFuzn.Tests/ExecutionType/Load/Warmup/AssertWhileWarmingUpTests.cs
+++ b/src/TestFuzn.Tests/ExecutionType/Load/Warmup/AssertWhileWarmingUpTests.cs
@@ -1,0 +1,145 @@
+namespace Fuzn.TestFuzn.Tests.ExecutionType.Load.Warmup;
+
+[TestClass]
+public class AssertWhileWarmingUpTests : Test
+{
+    [Test]
+    public async Task ShouldFail_Verify_stops_when_assertion_throws()
+    {
+        var warmupExecutionCount = 0;
+        var measurementExecutionCount = 0;
+        var catchExecuted = false;
+
+        try
+        {
+            await Scenario()
+                .Step("Step 1", (context) =>
+                {
+                    Assert.Fail("Simulated failure");
+                })
+                .Load().Warmup((context, simulations) =>
+                {
+                    simulations.OneTimeLoad(20);
+                })
+                .Load().AssertWhileWarmingUp((context, warmup) =>
+                {
+                    Interlocked.Increment(ref warmupExecutionCount);
+
+                    if (warmup.TotalCount >= 5 && warmup.FailedRate > 0.5)
+                        throw new Exception("Too many warmup failures");
+                })
+                .Load().Simulations((context, simulations) =>
+                {
+                    simulations.OneTimeLoad(10);
+                })
+                .Load().AssertWhenDone((context, stats) =>
+                {
+                    Interlocked.Increment(ref measurementExecutionCount);
+                })
+                .Run();
+        }
+        catch
+        {
+            catchExecuted = true;
+        }
+
+        Assert.IsTrue(catchExecuted, "Test should have failed due to warmup assertion");
+        Assert.IsGreaterThanOrEqualTo(5, warmupExecutionCount, "Assertion should have been evaluated at least 5 times");
+        Assert.AreEqual(0, measurementExecutionCount, "Measurement phase should not have been reached");
+    }
+
+    [Test]
+    public async Task Verify_does_not_stop_when_assertion_passes()
+    {
+        var executionCount = 0;
+
+        await Scenario()
+            .Step("Step 1", (context) =>
+            {
+                Interlocked.Increment(ref executionCount);
+            })
+            .Load().Warmup((context, simulations) =>
+            {
+                simulations.OneTimeLoad(10);
+            })
+            .Load().AssertWhileWarmingUp((context, warmup) =>
+            {
+                if (warmup.TotalCount >= 5 && warmup.FailedRate > 0.5)
+                    throw new Exception("Too many warmup failures");
+            })
+            .Load().Simulations((context, simulations) =>
+            {
+                simulations.OneTimeLoad(20);
+            })
+            .Load().AssertWhenDone((context, stats) =>
+            {
+                Assert.AreEqual(30, executionCount);
+                Assert.AreEqual(20, stats.RequestCount);
+            })
+            .Run();
+    }
+
+    [Test]
+    public async Task Verify_warmup_stats_properties()
+    {
+        var capturedStats = new List<WarmupStats>();
+
+        await Scenario()
+            .Step("Step 1", (context) =>
+            {
+                // All iterations pass
+            })
+            .Load().Warmup((context, simulations) =>
+            {
+                simulations.OneTimeLoad(5);
+            })
+            .Load().AssertWhileWarmingUp((context, warmup) =>
+            {
+                lock (capturedStats)
+                {
+                    capturedStats.Add(warmup);
+                }
+            })
+            .Load().Simulations((context, simulations) =>
+            {
+                simulations.OneTimeLoad(1);
+            })
+            .Run();
+
+        Assert.IsNotEmpty(capturedStats);
+
+        var lastStats = capturedStats.Last();
+        Assert.AreEqual(5, lastStats.TotalCount);
+        Assert.AreEqual(5, lastStats.OkCount);
+        Assert.AreEqual(0, lastStats.FailedCount);
+        Assert.AreEqual(1.0, lastStats.OkRate);
+        Assert.AreEqual(0.0, lastStats.FailedRate);
+        Assert.IsGreaterThan(TimeSpan.Zero, lastStats.Duration);
+    }
+
+    [Test]
+    public async Task Verify_without_assert_while_warming_up_works_as_before()
+    {
+        var executionCount = 0;
+
+        await Scenario()
+            .Step("Step 1", (context) =>
+            {
+                Interlocked.Increment(ref executionCount);
+            })
+            .Load().Warmup((context, simulations) =>
+            {
+                simulations.OneTimeLoad(10);
+            })
+            .Load().Simulations((context, simulations) =>
+            {
+                simulations.OneTimeLoad(20);
+            })
+            .Load().AssertWhenDone((context, stats) =>
+            {
+                Assert.AreEqual(30, executionCount);
+                Assert.AreEqual(20, stats.RequestCount);
+            })
+            .Run();
+    }
+}

--- a/src/TestFuzn.Tests/SyntaxTests.cs
+++ b/src/TestFuzn.Tests/SyntaxTests.cs
@@ -126,11 +126,17 @@ public class SyntaxTests : Test, IBeforeTest, IAfterTest
                 await context.Attach($"screenshot.png", new byte[0]);
                 await context.Attach($"screenshot.png", new MemoryStream());
             })
-            // Warmup simulations run before .Load().Simulations(). 
+            // Warmup simulations run before .Load().Simulations().
             // For these simulations no stats will be recorded, AssertWhileRunning, AssertWhenDone and sinks will not be called.
             .Load().Warmup((context, simulations) =>
             {
                 simulations.FixedConcurrentLoad(10, TimeSpan.FromSeconds(3));
+            })
+            // Assert during warmup. If the assertion throws, the test is stopped and marked as failed.
+            .Load().AssertWhileWarmingUp((context, warmup) =>
+            {
+                if (warmup.TotalCount >= 10 && warmup.FailedRate > 0.8)
+                    throw new Exception("Too many failures during warmup");
             })
             // Supports both sync and async.
             .Load().Simulations((context, simulations) =>

--- a/src/TestFuzn/AssertScenarioStats.cs
+++ b/src/TestFuzn/AssertScenarioStats.cs
@@ -22,6 +22,16 @@ public class AssertScenarioStats
     /// </summary>
     public AssertStats Failed { get; }
 
+    /// <summary>
+    /// Gets the rate of successful requests (0.0 to 1.0).
+    /// </summary>
+    public double OkRate { get; }
+
+    /// <summary>
+    /// Gets the rate of failed requests (0.0 to 1.0).
+    /// </summary>
+    public double FailedRate { get; }
+
     private Dictionary<string, AssertStepStats> _assertStepMetrics { get; set; }
 
     internal AssertScenarioStats(ScenarioLoadResult scenarioResult)
@@ -29,6 +39,8 @@ public class AssertScenarioStats
         RequestCount = scenarioResult.RequestCount;
         Ok = new AssertStats(scenarioResult.Ok);
         Failed = new AssertStats(scenarioResult.Failed);
+        OkRate = RequestCount == 0 ? 0 : (double)Ok.RequestCount / RequestCount;
+        FailedRate = RequestCount == 0 ? 0 : (double)Failed.RequestCount / RequestCount;
 
         _assertStepMetrics = new();
         foreach (var step in scenarioResult.Steps)

--- a/src/TestFuzn/Contracts/Results/Load/ScenarioLoadResult.cs
+++ b/src/TestFuzn/Contracts/Results/Load/ScenarioLoadResult.cs
@@ -31,6 +31,7 @@ internal class ScenarioLoadResult
     public int WarmupRequestCountOk { get; internal set; }
     public int WarmupRequestCountFailed { get; internal set; }
     public Dictionary<string, StepLoadResult> Steps { get; internal set; } = new();
+    public Exception? AssertWhileWarmingUpException { get; internal set; }
     public Exception? AssertWhileRunningException { get; internal set; }
     public Exception? AssertWhenDoneException { get; internal set; }
 

--- a/src/TestFuzn/Internals/ConsoleOutput/ConsoleWriter.cs
+++ b/src/TestFuzn/Internals/ConsoleOutput/ConsoleWriter.cs
@@ -435,9 +435,17 @@ internal class ConsoleWriter
             //Assertion
             var assertionSection = new StringBuilder();
 
-            if (loadResult.AssertWhileRunningException != null)
+            if (loadResult.AssertWhileWarmingUpException != null)
             {
                 assertionSection.AppendLine("[red]Assert exceptions:[/]");
+
+                assertionSection.AppendLine($"  [red]{loadResult.AssertWhileWarmingUpException.Message}[/]");
+            }
+
+            if (loadResult.AssertWhileRunningException != null)
+            {
+                if (assertionSection.Length == 0)
+                    assertionSection.AppendLine("[red]Assert exceptions:[/]");
 
                 assertionSection.AppendLine($"  [red]{loadResult.AssertWhileRunningException.Message}[/]");
             }

--- a/src/TestFuzn/Internals/Execution/ExecuteScenarioMessageHandler.cs
+++ b/src/TestFuzn/Internals/Execution/ExecuteScenarioMessageHandler.cs
@@ -100,6 +100,27 @@ internal class ExecuteScenarioMessageHandler
             if (message.IsWarmup)
             {
                 scenarioLoadCollector.RecordWarmup(executeStepHandler.CurrentScenarioStatus ?? TestStatus.Failed);
+
+                if (scenario.AssertWhileWarmingUpAction != null
+                    && _testExecutionState.ExecutionStatus == ExecutionStatus.Running)
+                {
+                    try
+                    {
+                        var warmupStats = scenarioLoadCollector.GetWarmupStats();
+                        var context = ContextFactory.CreateScenarioContext(_testExecutionState.TestSession, iterationServiceProvider, _testExecutionState.TestFramework, "AssertWhileWarmingUp", _testExecutionState.CancellationToken);
+                        scenario.AssertWhileWarmingUpAction(context, warmupStats);
+                    }
+                    catch (Exception ex)
+                    {
+                        _testExecutionState.ExecutionStatus = ExecutionStatus.Stopped;
+                        _testExecutionState.ExecutionStoppedReason = ex;
+                        _testExecutionState.TestResult.Status = TestStatus.Failed;
+                        _testExecutionState.FirstException = ex;
+                        scenarioLoadCollector.SetAssertWhileWarmingUpException(ex);
+                        scenarioLoadCollector.SetStatus(TestStatus.Failed);
+                    }
+                }
+
                 return;
             }
 

--- a/src/TestFuzn/Internals/Reports/Load/LoadHtmlReportWriter.cs
+++ b/src/TestFuzn/Internals/Reports/Load/LoadHtmlReportWriter.cs
@@ -227,7 +227,9 @@ internal class LoadHtmlReportWriter : ILoadReport
         else if (scenarioResult.Status == TestStatus.Failed)
         {
             var exception = "";
-            if (scenarioResult.AssertWhileRunningException != null)
+            if (scenarioResult.AssertWhileWarmingUpException != null)
+                exception = $"AssertWhileWarmingUp failed: {E(scenarioResult.AssertWhileWarmingUpException.Message)}";
+            else if (scenarioResult.AssertWhileRunningException != null)
                 exception = $"AssertWhileRunning failed: {E(scenarioResult.AssertWhileRunningException.Message)}";
             else if (scenarioResult.AssertWhenDoneException != null)
                 exception = $"AssertWhenDone failed: {E(scenarioResult.AssertWhenDoneException.Message)}";
@@ -550,6 +552,14 @@ internal class LoadHtmlReportWriter : ILoadReport
             return;
 
         b.AppendLine($"<h3>Failure Details</h3>");
+
+        if (scenarioResult.AssertWhileWarmingUpException != null)
+        {
+            b.AppendLine(@"<div class=""status-panel failed"">");
+            b.AppendLine(@"<div class=""title"">AssertWhileWarmingUp Failed</div>");
+            b.AppendLine($@"<div class=""details"">{E(scenarioResult.AssertWhileWarmingUpException.Message)}</div>");
+            b.AppendLine("</div>");
+        }
 
         if (scenarioResult.AssertWhileRunningException != null)
         {

--- a/src/TestFuzn/Internals/Results/Load/ScenarioLoadCollector.cs
+++ b/src/TestFuzn/Internals/Results/Load/ScenarioLoadCollector.cs
@@ -29,6 +29,7 @@ internal class ScenarioLoadCollector
     private int _warmupRequestCountFailed = 0;
     private ScenarioLoadResult _cachedCurrentResult;
     private DateTime _lastUpdated;
+    private Exception _assertWhileWarmingUpException;
     private Exception _assertWhileRunningException;
     private Exception _assertWhenDoneException;
     private Scenario _scenario;
@@ -57,6 +58,15 @@ internal class ScenarioLoadCollector
                 _warmupRequestCountOk++;
             else if (status == TestStatus.Failed)
                 _warmupRequestCountFailed++;
+        }
+    }
+
+    internal WarmupStats GetWarmupStats()
+    {
+        lock (_lock)
+        {
+            var duration = _warmupStartTime != default ? DateTime.UtcNow - _warmupStartTime : TimeSpan.Zero;
+            return new WarmupStats(_warmupRequestCountOk, _warmupRequestCountFailed, duration);
         }
     }
 
@@ -196,6 +206,7 @@ internal class ScenarioLoadCollector
             {
                 result.Steps.Add(step.Key, step.Value.GetCurrentResult());
             }
+            result.AssertWhileWarmingUpException = _assertWhileWarmingUpException;
             result.AssertWhileRunningException = _assertWhileRunningException;
             result.AssertWhenDoneException = _assertWhenDoneException;
             // Cleanup phase.
@@ -206,6 +217,15 @@ internal class ScenarioLoadCollector
             _cachedCurrentResult = result;
 
             return result;
+        }
+    }
+
+    internal void SetAssertWhileWarmingUpException(Exception exception)
+    {
+        lock (_lock)
+        {
+            _assertWhileWarmingUpException = exception;
+            _lastUpdated = DateTime.UtcNow;
         }
     }
 

--- a/src/TestFuzn/LoadBuilder.cs
+++ b/src/TestFuzn/LoadBuilder.cs
@@ -87,6 +87,18 @@ public class LoadBuilder<TModel>
     }
 
     /// <summary>
+    /// Registers an assertion action to run after each warmup iteration.
+    /// If an assertion throws an exception, the load test will be stopped and marked as failed.
+    /// </summary>
+    /// <param name="action">The action that performs assertions on warmup statistics.</param>
+    /// <returns>The parent <see cref="ScenarioBuilder{TModel}"/> instance for method chaining.</returns>
+    public ScenarioBuilder<TModel> AssertWhileWarmingUp(Action<Context, WarmupStats> action)
+    {
+        _scenarioBuilder.Scenario.AssertWhileWarmingUpAction = action;
+        return _scenarioBuilder;
+    }
+
+    /// <summary>
     /// Registers an assertion action to run periodically while the load test is running.
     /// If an assertion fails, the load test will be stopped and marked as failed.
     /// </summary>

--- a/src/TestFuzn/Scenario.cs
+++ b/src/TestFuzn/Scenario.cs
@@ -28,6 +28,7 @@ internal class Scenario
     internal Func<ScenarioContext, SimulationsBuilder, Task> WarmupAction;
     internal Func<ScenarioContext, SimulationsBuilder, Task> SimulationsAction;
     internal List<ILoadConfiguration> SimulationsInternal { get; } = new();
+    internal Action<ScenarioContext, WarmupStats>? AssertWhileWarmingUpAction;
     internal Action<ScenarioContext, AssertScenarioStats>? AssertWhileRunningAction;
     internal Action<ScenarioContext, AssertScenarioStats>? AssertWhenDoneAction;
 

--- a/src/TestFuzn/WarmupStats.cs
+++ b/src/TestFuzn/WarmupStats.cs
@@ -1,0 +1,44 @@
+namespace Fuzn.TestFuzn;
+
+/// <summary>
+/// Provides warmup phase statistics for assertions during warmup.
+/// </summary>
+public class WarmupStats
+{
+    /// <summary>
+    /// Gets the number of successful warmup iterations.
+    /// </summary>
+    public int OkCount { get; }
+
+    /// <summary>
+    /// Gets the number of failed warmup iterations.
+    /// </summary>
+    public int FailedCount { get; }
+
+    /// <summary>
+    /// Gets the total number of warmup iterations (OkCount + FailedCount).
+    /// </summary>
+    public int TotalCount => OkCount + FailedCount;
+
+    /// <summary>
+    /// Gets the rate of successful warmup iterations (0.0 to 1.0).
+    /// </summary>
+    public double OkRate => TotalCount == 0 ? 0 : (double) OkCount / TotalCount;
+
+    /// <summary>
+    /// Gets the rate of failed warmup iterations (0.0 to 1.0).
+    /// </summary>
+    public double FailedRate => TotalCount == 0 ? 0 : (double) FailedCount / TotalCount;
+
+    /// <summary>
+    /// Gets the elapsed time since the warmup phase started.
+    /// </summary>
+    public TimeSpan Duration { get; }
+
+    internal WarmupStats(int okCount, int failedCount, TimeSpan elapsed)
+    {
+        OkCount = okCount;
+        FailedCount = failedCount;
+        Duration = elapsed;
+    }
+}


### PR DESCRIPTION
- Add AssertWhileWarmingUp to stop load tests early when warmup iterations are consistently failing, following the same exception-based pattern as AssertWhileRunning and AssertWhenDone. 
- Add OkRate/FailedRate properties to AssertScenarioStats and WarmupStats for convenient rate checking.