### PR TITLE
feat: rename output-directory to results-directory

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -55,7 +55,7 @@
 | `NodeName` | The name of the machine where the tests are running |
 | `ServiceProvider` | The `IServiceProvider` for resolving dependencies registered during test initialization |
 | `Logger` | The `ILogger` instance used for writing test log output |
-| `TestsOutputDirectory` | The output directory where test results and artifacts are written |
+| `TestsResultsDirectory` | The directory where test results and artifacts are written |
 | `TestRunId` | The unique identifier for the current test run |
 
 ---

--- a/docs/test-reports.md
+++ b/docs/test-reports.md
@@ -32,7 +32,7 @@ The load test reports include:
 
 ## Report Location
 
-Reports are saved under a `TestFuznResults` directory:
+By default, reports are saved under a `TestFuznResults` directory next to the test framework's own results folder:
 
 ```
 {base}/TestFuznResults/{assembly-name}/{run-id}/
@@ -43,9 +43,17 @@ Reports are saved under a `TestFuznResults` directory:
 ├──  Attachments/
 ```
 
-By default, `{base}` is the test framework's results directory (e.g., MSTest's `TestResults` folder). You can override it with:
-- Environment variable: `TESTFUZN_OUTPUT_DIRECTORY`
-- Command line: `--output-directory <path>`
+`{base}` is the parent of the test framework's results folder — for MSTest that means `TestFuznResults` is created as a sibling of MSTest's `TestResults`, not inside it.
+
+You can override the location with:
+- Environment variable: `TESTFUZN_RESULTS_DIRECTORY`
+- Command line: `--results-directory <path>`
+
+When a custom results directory is supplied, the extra `TestFuznResults` segment is **not** appended — TestFuzn writes directly into the directory you specified:
+
+```
+{custom-results-directory}/{assembly-name}/{run-id}/
+```
 
 ### Report Retention
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>0.7.0</Version>
+    <Version>0.7.1</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Authors>Fuzn</Authors>

--- a/src/TestFuzn.Adapters.MSTest/Adapters/MsTestRunnerAdapter.cs
+++ b/src/TestFuzn.Adapters.MSTest/Adapters/MsTestRunnerAdapter.cs
@@ -199,7 +199,18 @@ internal class MsTestRunnerAdapter(TestContext testContext) : ITestFrameworkAdap
         throw new NotImplementedException("Should not happen");
     }
 
-    public string TestResultsDirectory => new DirectoryInfo(_testContext.TestRunDirectory).Parent.Parent.ToString();
+    public string TestResultsDirectory
+    {
+        get
+        {
+            // _testContext.TestRunDirectory is the per-run deploy folder, e.g.
+            //   <buildOutput>\TestResults\Deploy_<machine> <timestamp>
+            // Walking up two levels lands at <buildOutput>, so TestFuzn writes its
+            // TestFuznResults folder as a sibling of MSTest's TestResults folder.
+            var testResultsFolder = Path.GetDirectoryName(_testContext.TestRunDirectory);
+            return Path.GetDirectoryName(testResultsFolder)!;
+        }
+    }
 
     private static string StripMarkup(string input)
     {

--- a/src/TestFuzn.Tests.Attributes/GlobalStates/GlobalStateTests.cs
+++ b/src/TestFuzn.Tests.Attributes/GlobalStates/GlobalStateTests.cs
@@ -45,9 +45,9 @@ public class GlobalStateTests
     }
 
     [TestMethod]
-    public void TestsOutputDirectoryContainsTestRunId()
+    public void TestsResultsDirectoryContainsTestRunId()
     {
-        Assert.IsTrue(GlobalState.TestsOutputDirectory.Contains(GlobalState.TestRunId));
+        Assert.IsTrue(GlobalState.TestsResultsDirectory.Contains(GlobalState.TestRunId));
     }
 
     [TestMethod]

--- a/src/TestFuzn.Tests/Session/ResultsDirectoryTests.cs
+++ b/src/TestFuzn.Tests/Session/ResultsDirectoryTests.cs
@@ -4,7 +4,7 @@ using Fuzn.TestFuzn.Internals.AppConfiguration;
 namespace Fuzn.TestFuzn.Tests.Session;
 
 [TestClass]
-public class OutputDirectoryTests : Test, IStartup
+public class ResultsDirectoryTests : Test, IStartup
 {
     private static string _tempBaseDirectory = null!;
     private static string _assemblyOutputDirectory = null!;
@@ -14,8 +14,8 @@ public class OutputDirectoryTests : Test, IStartup
     {
         _tempBaseDirectory = Path.Combine(Path.GetTempPath(), $"TestFuzn_OutputDirTest_{Guid.NewGuid():N}");
 
-        var testSession = new TestSession(nameof(OutputDirectoryTests));
-        await testSession.Init<OutputDirectoryTests>(
+        var testSession = new TestSession(nameof(ResultsDirectoryTests));
+        await testSession.Init<ResultsDirectoryTests>(
             new EnvironmentWrapper(),
             new FileSystem(),
             new ConfigurationLoader(),
@@ -23,13 +23,13 @@ public class OutputDirectoryTests : Test, IStartup
             new MsTestRunnerAdapter(testContext),
             args: new Dictionary<string, string>
             {
-                ["output-directory"] = _tempBaseDirectory,
+                ["results-directory"] = _tempBaseDirectory,
                 ["keep-last-n-runs"] = "2"
             });
         TestSessionRegistry.Add(testSession);
 
         // The parent directory contains all runs for this assembly
-        _assemblyOutputDirectory = Path.GetDirectoryName(testSession.TestsOutputDirectory)!;
+        _assemblyOutputDirectory = Path.GetDirectoryName(testSession.TestsResultsDirectory)!;
     }
 
     [ClassCleanup]
@@ -47,34 +47,74 @@ public class OutputDirectoryTests : Test, IStartup
     {
     }
 
-    [Test(TestSessionId = nameof(OutputDirectoryTests))]
-    public async Task Custom_output_directory_is_used_as_base_path()
+    [Test(TestSessionId = nameof(ResultsDirectoryTests))]
+    public async Task Custom_results_directory_is_used_as_base_path()
     {
         await Scenario()
-            .Step("Verify output directory uses custom base path", context =>
+            .Step("Verify results directory uses custom base path", context =>
             {
-                Assert.StartsWith(_tempBaseDirectory, TestSession.Current.TestsOutputDirectory);
+                Assert.StartsWith(_tempBaseDirectory, TestSession.Current.TestsResultsDirectory);
             })
-            .Step("Verify TestFuznResults structure is appended", context =>
+            .Step("Verify TestFuznResults segment is NOT appended for custom results directory", context =>
             {
-                Assert.Contains("TestFuznResults", TestSession.Current.TestsOutputDirectory);
+                // When the user explicitly sets results-directory, TestFuzn must not nest
+                // an extra TestFuznResults folder underneath -- the user already chose the location.
+                Assert.DoesNotContain("TestFuznResults", TestSession.Current.TestsResultsDirectory);
+            })
+            .Step("Verify layout is <customDir>/<assemblyName>/<runId>", context =>
+            {
+                var assemblyName = typeof(ResultsDirectoryTests).Assembly.GetName().Name!;
+                var expectedPrefix = Path.Combine(_tempBaseDirectory, assemblyName);
+                Assert.StartsWith(expectedPrefix, TestSession.Current.TestsResultsDirectory);
             })
             .Run();
     }
 
-    [Test(TestSessionId = nameof(OutputDirectoryTests))]
+    [Test(TestSessionId = nameof(ResultsDirectoryTests))]
+    public async Task Default_results_directory_uses_test_framework_path_with_TestFuznResults_segment()
+    {
+        // Build a session WITHOUT a custom results-directory so we exercise the default path
+        // (testFramework.TestResultsDirectory + "TestFuznResults" + assemblyName + runId).
+        TestSession defaultSession = null!;
+
+        await Scenario()
+            .Step("Init session without custom results-directory", async context =>
+            {
+                defaultSession = new TestSession($"{nameof(ResultsDirectoryTests)}_default");
+                await defaultSession.Init<ResultsDirectoryTests>(
+                    new EnvironmentWrapper(),
+                    new FileSystem(),
+                    new ConfigurationLoader(),
+                    new ArgumentsParser(new EnvironmentWrapper()),
+                    new MsTestRunnerAdapter(TestContext));
+            })
+            .Step("Verify TestFuznResults segment is present", context =>
+            {
+                Assert.Contains("TestFuznResults", defaultSession.TestsResultsDirectory);
+            })
+            .Step("Verify TestFuznResults sits next to MSTest TestResults (not inside it)", context =>
+            {
+                // The MSTest adapter returns the parent of the TestResults folder, so the
+                // resulting path should NOT contain a "TestResults/TestFuznResults" segment.
+                var combined = Path.Combine("TestResults", "TestFuznResults");
+                Assert.DoesNotContain(combined, defaultSession.TestsResultsDirectory);
+            })
+            .Run();
+    }
+
+    [Test(TestSessionId = nameof(ResultsDirectoryTests))]
     public async Task Marker_file_exists_in_output_directory()
     {
         await Scenario()
             .Step("Verify .testfuzn marker file exists", context =>
             {
-                var markerPath = Path.Combine(TestSession.Current.TestsOutputDirectory, ".testfuzn");
+                var markerPath = Path.Combine(TestSession.Current.TestsResultsDirectory, ".testfuzn");
                 Assert.IsTrue(File.Exists(markerPath), $"Marker file not found at {markerPath}");
             })
             .Run();
     }
 
-    [Test(TestSessionId = nameof(OutputDirectoryTests))]
+    [Test(TestSessionId = nameof(ResultsDirectoryTests))]
     public async Task Cleanup_deletes_old_runs_with_marker_and_preserves_unmarked()
     {
         await Scenario()
@@ -96,7 +136,7 @@ public class OutputDirectoryTests : Test, IStartup
             })
             .Step("Trigger cleanup by calling session Cleanup", async context =>
             {
-                var session = TestSessionRegistry.Get(nameof(OutputDirectoryTests));
+                var session = TestSessionRegistry.Get(nameof(ResultsDirectoryTests));
                 var testFramework = new MsTestRunnerAdapter(TestContext);
                 await session.Cleanup(testFramework);
             })
@@ -104,7 +144,7 @@ public class OutputDirectoryTests : Test, IStartup
             {
                 // We have 4 marked directories: current run + old-run-1, old-run-2, old-run-3
                 // keep-last-n-runs=2, so the 2 oldest (old-run-2, old-run-3) should be deleted
-                var currentRunExists = Directory.Exists(TestSession.Current.TestsOutputDirectory);
+                var currentRunExists = Directory.Exists(TestSession.Current.TestsResultsDirectory);
                 Assert.IsTrue(currentRunExists, "Current run directory should still exist");
 
                 var oldRun1Exists = Directory.Exists(Path.Combine(_assemblyOutputDirectory, "old-run-1"));

--- a/src/TestFuzn/Contexts/IterationContext.cs
+++ b/src/TestFuzn/Contexts/IterationContext.cs
@@ -183,7 +183,7 @@ public abstract class IterationContext : Context
         if (StepInfo.Attachments == null)
             StepInfo.Attachments = new();
 
-        var directory = Path.Combine(Info.TestSession.TestsOutputDirectory, "Data", "Attachments");
+        var directory = Path.Combine(Info.TestSession.TestsResultsDirectory, "Data", "Attachments");
         if (!fileSystem.DirectoryExists(directory))
             fileSystem.CreateDirectory(directory);
 

--- a/src/TestFuzn/Contracts/Reports/LoadReportData.cs
+++ b/src/TestFuzn/Contracts/Reports/LoadReportData.cs
@@ -7,7 +7,7 @@ internal class LoadReportData
 {
     public SuiteInfo Suite { get; set; } = null!;
     public string TestRunId { get; internal set; } = null!;
-    public string TestsOutputDirectory { get; internal set; } = null!;
+    public string TestsResultsDirectory { get; internal set; } = null!;
     public TestResult Test { get; internal set; } = null!;
     public Dictionary<string, IReadOnlyList<ScenarioLoadResult>> Snapshots { get; internal set; } = new();
     public List<ScenarioLoadResult> ScenarioResults { get; internal set; } = new();

--- a/src/TestFuzn/Contracts/Reports/StandardReportData.cs
+++ b/src/TestFuzn/Contracts/Reports/StandardReportData.cs
@@ -10,6 +10,6 @@ internal class StandardReportData
     public DateTime TestRunStartTime { get; internal set; }
     public DateTime TestRunEndTime { get; internal set; }
     public TimeSpan TestRunDuration { get; internal set; }
-    public string TestsOutputDirectory { get; internal set; }
+    public string TestsResultsDirectory { get; internal set; }
     public ConcurrentDictionary<string, GroupResult> GroupResults { get; internal set; }
 }

--- a/src/TestFuzn/GlobalState.cs
+++ b/src/TestFuzn/GlobalState.cs
@@ -51,9 +51,9 @@ public static class GlobalState
     public static ILogger Logger => GetTestSession().Logger;
 
     /// <summary>
-    /// Gets the output directory where test results and artifacts are written.
+    /// Gets the directory where test results and artifacts are written.
     /// </summary>
-    public static string TestsOutputDirectory => GetTestSession().TestsOutputDirectory;
+    public static string TestsResultsDirectory => GetTestSession().TestsResultsDirectory;
 
     /// <summary>
     /// Gets the unique identifier for the current test run.

--- a/src/TestFuzn/Internals/Logging/LoggerFactory.cs
+++ b/src/TestFuzn/Internals/Logging/LoggerFactory.cs
@@ -8,16 +8,16 @@ internal static class LoggerFactory
     /// <summary>
     /// Creates a logger instance for the given output directory
     /// </summary>
-    public static ILogger CreateLogger(IFileSystem fileSystem, string testsOutputDirectory, string categoryName = "TestFuzn")
+    public static ILogger CreateLogger(IFileSystem fileSystem, string testsResultsDirectory, string categoryName = "TestFuzn")
     {
         try
         {
-            var logsPath = testsOutputDirectory;
+            var logsPath = testsResultsDirectory;
             if (string.IsNullOrEmpty(logsPath))
             {
                 // Fallback to temp directory if output directory is not set
                 logsPath = Path.Combine(Path.GetTempPath(), "TestFuzn_Logs", DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss"));
-                Console.WriteLine($"WARNING: TestsOutputDirectory not set, using temporary path: {logsPath}");
+                Console.WriteLine($"WARNING: TestsResultsDirectory not set, using temporary path: {logsPath}");
             }
             string? directory = Path.GetDirectoryName(logsPath);
             if (!string.IsNullOrEmpty(directory))

--- a/src/TestFuzn/Internals/Reports/Load/LoadHtmlReportWriter.cs
+++ b/src/TestFuzn/Internals/Reports/Load/LoadHtmlReportWriter.cs
@@ -25,7 +25,7 @@ internal class LoadHtmlReportWriter : ILoadReport
         try
         {
             var reportName = FileNameHelper.MakeFilenameSafe($"{loadReportData.Test.Group.Name}-{loadReportData.Test.Name}");
-            var directory = Path.Combine(loadReportData.TestsOutputDirectory, "Data");
+            var directory = Path.Combine(loadReportData.TestsResultsDirectory, "Data");
             _fileSystem.CreateDirectory(directory);
             var filePath = Path.Combine(directory, $"{reportName}.html");
 

--- a/src/TestFuzn/Internals/Reports/Load/LoadReportManager.cs
+++ b/src/TestFuzn/Internals/Reports/Load/LoadReportManager.cs
@@ -33,7 +33,7 @@ internal class LoadReportManager
         data.Suite.Metadata = _testSession.Configuration.Suite.Metadata;
         data.TestRunId = _testSession.TestRunId;
         data.Test = testExecutionState.TestResult;
-        data.TestsOutputDirectory = _testSession.TestsOutputDirectory;
+        data.TestsResultsDirectory = _testSession.TestsResultsDirectory;
 
         foreach (var scenario in testExecutionState.Scenarios)
         {

--- a/src/TestFuzn/Internals/Reports/Load/LoadXmlReportWriter.cs
+++ b/src/TestFuzn/Internals/Reports/Load/LoadXmlReportWriter.cs
@@ -23,7 +23,7 @@ internal class LoadXmlReportWriter : ILoadReport
         try
         {
             var reportName = FileNameHelper.MakeFilenameSafe($"{loadReportData.Test.Group.Name}-{loadReportData.Test.Name}");
-            var directory = Path.Combine(_testSession.TestsOutputDirectory, "Data");
+            var directory = Path.Combine(_testSession.TestsResultsDirectory, "Data");
             _fileSystem.CreateDirectory(directory);
             var filePath = Path.Combine(directory, $"{reportName}.xml");
 

--- a/src/TestFuzn/Internals/Reports/Standard/StandardHtmlReportWriter.cs
+++ b/src/TestFuzn/Internals/Reports/Standard/StandardHtmlReportWriter.cs
@@ -25,7 +25,7 @@ internal class StandardHtmlReportWriter : IStandardReport
     {
         try
         {
-            var filePath = Path.Combine(reportData.TestsOutputDirectory, "TestReport.html");
+            var filePath = Path.Combine(reportData.TestsResultsDirectory, "TestReport.html");
 
             var htmlContent = GenerateHtmlReport(reportData);
 

--- a/src/TestFuzn/Internals/Reports/Standard/StandardReportManager.cs
+++ b/src/TestFuzn/Internals/Reports/Standard/StandardReportManager.cs
@@ -28,7 +28,7 @@ internal class StandardReportManager
         data.TestRunStartTime = _testSession.TestRunStartTime;
         data.TestRunEndTime = _testSession.TestRunEndTime;
         data.TestRunDuration = data.TestRunEndTime - data.TestRunStartTime;
-        data.TestsOutputDirectory = _testSession.TestsOutputDirectory;
+        data.TestsResultsDirectory = _testSession.TestsResultsDirectory;
         data.GroupResults = groupResults.GroupResults;
 
         foreach (var standardReport in _standardReports)

--- a/src/TestFuzn/Internals/Reports/Standard/StandardXmlReportWriter.cs
+++ b/src/TestFuzn/Internals/Reports/Standard/StandardXmlReportWriter.cs
@@ -22,7 +22,7 @@ internal class StandardXmlReportWriter : IStandardReport
     {
         try
         {
-            var directory = Path.Combine(reportData.TestsOutputDirectory, "Data");
+            var directory = Path.Combine(reportData.TestsResultsDirectory, "Data");
             _fileSystem.CreateDirectory(directory);
             var filePath = Path.Combine(directory, "TestReport.xml");
 

--- a/src/TestFuzn/Internals/TestSession.cs
+++ b/src/TestFuzn/Internals/TestSession.cs
@@ -49,7 +49,7 @@ internal class TestSession
     }
 
     internal bool IsInitializeGlobalExecuted { get; set; } = false;
-    internal string TestsOutputDirectory { get; set; }
+    internal string TestsResultsDirectory { get; set; }
     internal TestFuznConfiguration Configuration { get; set; }
     internal bool LoadTestWasExecuted { get; set; } = false;
     internal ILogger Logger { get; set; }
@@ -132,17 +132,16 @@ internal class TestSession
 
         var testAssemblyName = StartupInstance.GetType().Assembly.GetName().Name;
 
-        var customOutputDirectory = argumentParser.GetValueFromArgsOrEnvironmentVariable(
-                                        args, "output-directory", "TESTFUZN_OUTPUT_DIRECTORY");
-        var baseDirectory = !string.IsNullOrWhiteSpace(customOutputDirectory)
-            ? customOutputDirectory
-            : testFramework.TestResultsDirectory;
-        TestsOutputDirectory = Path.Combine(baseDirectory, "TestFuznResults", testAssemblyName, $"{TestRunId}");
+        var customResultsDirectory = argumentParser.GetValueFromArgsOrEnvironmentVariable(
+                                        args, "results-directory", "TESTFUZN_RESULTS_DIRECTORY");
+        TestsResultsDirectory = !string.IsNullOrWhiteSpace(customResultsDirectory)
+            ? Path.Combine(customResultsDirectory, testAssemblyName, $"{TestRunId}")
+            : Path.Combine(testFramework.TestResultsDirectory, "TestFuznResults", testAssemblyName, $"{TestRunId}");
         if (Id != "default")
-            TestsOutputDirectory = TestsOutputDirectory + "_" + Id;
+            TestsResultsDirectory = TestsResultsDirectory + "_" + Id;
 
-        fileSystem.CreateDirectory(TestsOutputDirectory);
-        await fileSystem.WriteAllTextAsync(Path.Combine(TestsOutputDirectory, MarkerFileName), "");
+        fileSystem.CreateDirectory(TestsResultsDirectory);
+        await fileSystem.WriteAllTextAsync(Path.Combine(TestsResultsDirectory, MarkerFileName), "");
 
         _fileSystem = fileSystem;
         var keepLastNRunsValue = argumentParser.GetValueFromArgsOrEnvironmentVariable(
@@ -150,7 +149,7 @@ internal class TestSession
         if (!string.IsNullOrWhiteSpace(keepLastNRunsValue) && int.TryParse(keepLastNRunsValue, out var parsed) && parsed >= 0)
             _keepLastNRuns = parsed;
 
-        Logger = Internals.Logging.LoggerFactory.CreateLogger(fileSystem, TestsOutputDirectory);
+        Logger = Internals.Logging.LoggerFactory.CreateLogger(fileSystem, TestsResultsDirectory);
         Logger.LogInformation("Logging initialized");
 
         var configRoot = configurationLoader.LoadConfigRoot(
@@ -190,10 +189,10 @@ internal class TestSession
             await plugin.InitSuite();
 
         await EmbeddedResourceHelper.WriteEmbeddedResourceToFile(fileSystem, "Fuzn.TestFuzn.Internals.Reports.EmbeddedResources.Styles.testfuzn.css",
-                                        Path.Combine(TestsOutputDirectory, "Data/Assets/styles/testfuzn.css"));
+                                        Path.Combine(TestsResultsDirectory, "Data/Assets/styles/testfuzn.css"));
 
         await EmbeddedResourceHelper.WriteEmbeddedResourceToFile(fileSystem, "Fuzn.TestFuzn.Internals.Reports.EmbeddedResources.Scripts.chart.js",
-                                        Path.Combine(TestsOutputDirectory, "Data/Assets/scripts/chart.js"));
+                                        Path.Combine(TestsResultsDirectory, "Data/Assets/scripts/chart.js"));
 
         IsInitializeGlobalExecuted = true;
     }
@@ -259,7 +258,7 @@ internal class TestSession
         if (_fileSystem == null || _keepLastNRuns <= 0)
             return;
 
-        var parentDirectory = Path.GetDirectoryName(TestsOutputDirectory);
+        var parentDirectory = Path.GetDirectoryName(TestsResultsDirectory);
         if (parentDirectory == null || !_fileSystem.DirectoryExists(parentDirectory))
             return;
 

--- a/src/TestFuzn/StandaloneRunner/BaseStandaloneRunnerAdapter.cs
+++ b/src/TestFuzn/StandaloneRunner/BaseStandaloneRunnerAdapter.cs
@@ -251,9 +251,11 @@ internal abstract class BaseStandaloneRunnerAdapter : ITestFrameworkAdapter, IDi
     {
         get
         {
+            // Returns the entry assembly's directory so TestFuzn writes its
+            // TestFuznResults folder there, matching the MSTest adapter which
+            // places TestFuznResults as a sibling of MSTest's TestResults folder.
             var assemblyLocation = System.Reflection.Assembly.GetEntryAssembly().Location;
-            var directory = Path.Combine(Path.GetDirectoryName(assemblyLocation)!, "TestResults");
-            return directory;
+            return Path.GetDirectoryName(assemblyLocation)!;
         }
     }
 


### PR DESCRIPTION
- TESTFUZN_OUTPUT_DIRECTORY -> TESTFUZN_RESULTS_DIRECTORY
- --output-directory -> --results-directory

When --results-directory is supplied, results are now written directly to <custom>/<assembly>/<runId> with no extra TestFuznResults segment.