### PR TITLE
feat: optimize execution pipeline performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,6 +398,7 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea/
 
 # Local appsettings
 **/appsettings.frankintel.json

--- a/src/TestFuzn.Tests/ExecutionType/Load/Warmup/AssertWhileWarmingUpTests.cs
+++ b/src/TestFuzn.Tests/ExecutionType/Load/Warmup/AssertWhileWarmingUpTests.cs
@@ -108,7 +108,7 @@ public class AssertWhileWarmingUpTests : Test
 
         Assert.IsNotEmpty(capturedStats);
 
-        var lastStats = capturedStats.Last();
+        var lastStats = capturedStats.OrderByDescending(s => s.TotalCount).First();
         Assert.AreEqual(5, lastStats.TotalCount);
         Assert.AreEqual(5, lastStats.OkCount);
         Assert.AreEqual(0, lastStats.FailedCount);

--- a/src/TestFuzn.slnx
+++ b/src/TestFuzn.slnx
@@ -41,4 +41,7 @@
   <Project Path="TestFuzn.Tests.DefaultHttpClient/TestFuzn.Tests.DefaultHttpClient.csproj" />
   <Project Path="TestFuzn.Tests.Runner/TestFuzn.Tests.Runner.csproj" />
   <Project Path="TestWebApp/TestWebApp.csproj" />
+  <Project Path="docker-compose.dcproj">
+    <Build />
+  </Project>
 </Solution>

--- a/src/TestFuzn/Internals/ContextFactory.cs
+++ b/src/TestFuzn/Internals/ContextFactory.cs
@@ -1,11 +1,23 @@
-﻿using Fuzn.TestFuzn.Contracts.Adapters;
-using Fuzn.TestFuzn.Internals.State;
-using Microsoft.Extensions.DependencyInjection;
+﻿using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using Fuzn.TestFuzn.Contracts.Adapters;
 
 namespace Fuzn.TestFuzn.Internals;
 
 internal class ContextFactory
 {
+    private static readonly ConcurrentDictionary<Type, Func<object>> FactoryCache = new();
+
+    private static Func<object> GetOrCreateFactory(Type type)
+    {
+        return FactoryCache.GetOrAdd(type, t =>
+        {
+            var newExpr = Expression.New(t);
+            var lambda = Expression.Lambda<Func<object>>(Expression.Convert(newExpr, typeof(object)));
+            return lambda.Compile();
+        });
+    }
+
     public static Context CreateContext(
         TestSession testSession,
         IServiceProvider serviceProvider,
@@ -18,7 +30,7 @@ internal class ContextFactory
         if (testSession.Configuration != null)
         {
             context.IterationState = new();
-            PopulateIterationStateProperties(context.IterationState, testSession, serviceProvider, testFramework, cancellationToken);
+            PopulateIterationStateProperties(context.IterationState, testSession, serviceProvider, testFramework, Guid.NewGuid(), cancellationToken);
             context.StepInfo = new StepInfo(null, stepName, null, null);
         }
 
@@ -37,7 +49,7 @@ internal class ContextFactory
         if (testSession.Configuration != null)
         {
             context.IterationState = new();
-            PopulateIterationStateProperties(context.IterationState, testSession, serviceProvider, testFramework, cancellationToken);
+            PopulateIterationStateProperties(context.IterationState, testSession, serviceProvider, testFramework, Guid.NewGuid(), cancellationToken);
             context.StepInfo = new StepInfo(null, stepName, null, null);
         }
 
@@ -46,7 +58,8 @@ internal class ContextFactory
 
     public static IterationContext CreateIterationContext(IterationState iterationState, string stepName, string? stepId, string? parentName)
     {
-        var contextObj = Activator.CreateInstance(iterationState.Scenario.ContextType);
+        var factory = GetOrCreateFactory(iterationState.Scenario.ContextType);
+        var contextObj = factory();
         if (contextObj is not IterationContext context)
             throw new InvalidOperationException($"Failed to create instance of {iterationState.Scenario.ContextType}");
 
@@ -62,20 +75,22 @@ internal class ContextFactory
         ITestFrameworkAdapter testFramework,
         Scenario scenario, object?
         currentInput,
+        Guid correlationId,
         CancellationToken cancellationToken = default)
     {
         var iterationState = new IterationState();
         if (scenario.ContextType.IsGenericType && scenario.ContextType.GetGenericTypeDefinition() == typeof(IterationContext<>))
         {
             var modelType = scenario.ContextType.GetGenericArguments()[0];
-            var modelInstance = Activator.CreateInstance(modelType);
+            var modelFactory = GetOrCreateFactory(modelType);
+            var modelInstance = modelFactory();
 
             if (modelInstance == null)
                 throw new InvalidOperationException($"Failed to create instance of {modelType}");
 
             iterationState.Model = modelInstance;
         }
-        PopulateIterationStateProperties(iterationState, testSession, serviceProvider, testFramework, cancellationToken);
+        PopulateIterationStateProperties(iterationState, testSession, serviceProvider, testFramework, correlationId, cancellationToken);
         iterationState.SharedData = new();
         iterationState.Scenario = scenario;
         iterationState.InputData = currentInput;
@@ -88,11 +103,12 @@ internal class ContextFactory
         TestSession testSession,
         IServiceProvider serviceProvider,
         ITestFrameworkAdapter testFramework,
+        Guid correlationId,
         CancellationToken cancellationToken)
     {
         iterationState.Info = new ExecutionInfo();
         iterationState.Info.TestSession = testSession;
-        iterationState.Info.CorrelationId = Guid.NewGuid().ToString();
+        iterationState.Info.CorrelationId = correlationId.ToString();
         iterationState.Info.CancellationToken = cancellationToken;
         iterationState.TestFramework = testFramework;
         iterationState.ServiceProvider = serviceProvider;

--- a/src/TestFuzn/Internals/Execution/Consumers/ConsumerManager.cs
+++ b/src/TestFuzn/Internals/Execution/Consumers/ConsumerManager.cs
@@ -1,5 +1,4 @@
 ﻿using Fuzn.TestFuzn.Contracts;
-using Fuzn.TestFuzn.Contracts.Results.Load;
 using Fuzn.TestFuzn.Internals.State;
 
 namespace Fuzn.TestFuzn.Internals.Execution.Consumers;
@@ -33,12 +32,10 @@ internal class ConsumerManager
 
         await Parallel.ForEachAsync(
             queue.GetConsumingEnumerable(cancellationToken), 
-            new ParallelOptions { CancellationToken = cancellationToken },
+            new ParallelOptions { MaxDegreeOfParallelism = int.MaxValue, CancellationToken = cancellationToken },
             async (message, ct) =>
         {
-            var scenario = _testExecutionState.Scenarios.Single(s => s.Name == message.ScenarioName);
-
-            await _executeScenarioMessageHandler.Execute(message, scenario);
+            await _executeScenarioMessageHandler.Execute(message);
 
             _testExecutionState.RemoveFromQueues(message);
 
@@ -46,9 +43,9 @@ internal class ConsumerManager
             {
                 if (_testExecutionState.TestResult.TestType == TestType.Load)
                 {
-                    _testExecutionState.LoadCollectors[message.ScenarioName].MarkPhaseAsCompleted(LoadTestPhase.Measurement, DateTime.UtcNow);
-                    var scenarioLoadResult = _testExecutionState.LoadCollectors[message.ScenarioName].GetCurrentResult(true);
-                    await _executeScenarioMessageHandler.WriteToSinksAndSnapshotCollector(_testExecutionState, scenario, scenarioLoadResult, true);
+                    var completedCollector = _testExecutionState.LoadCollectors[message.ScenarioName];
+                    completedCollector.MarkPhaseAsCompleted(LoadTestPhase.Measurement, DateTime.UtcNow);
+                    await _executeScenarioMessageHandler.WriteToSinksAndSnapshotCollector(_testExecutionState, message.Scenario, () => completedCollector.GetCurrentResult(true), true);
                 }
             }
         });

--- a/src/TestFuzn/Internals/Execution/ExecuteScenarioMessage.cs
+++ b/src/TestFuzn/Internals/Execution/ExecuteScenarioMessage.cs
@@ -3,13 +3,14 @@
 internal class ExecuteScenarioMessage
 {
     public Guid MessageId { get; set; }
-    public string ScenarioName { get; set; }
+    public Scenario Scenario { get; }
+    public string ScenarioName => Scenario.Name;
     public bool IsWarmup { get; }
-    
-    public ExecuteScenarioMessage(string scenarioName, bool isWarmup)
+
+    public ExecuteScenarioMessage(Scenario scenario, bool isWarmup)
     {
         MessageId = Guid.NewGuid();
-        ScenarioName = scenarioName;
+        Scenario = scenario;
         IsWarmup = isWarmup;
     }
 }

--- a/src/TestFuzn/Internals/Execution/ExecuteScenarioMessageHandler.cs
+++ b/src/TestFuzn/Internals/Execution/ExecuteScenarioMessageHandler.cs
@@ -2,6 +2,7 @@
 using Fuzn.TestFuzn.Contracts.Results.Standard;
 using Fuzn.TestFuzn.Contracts.Results.Load;
 using Fuzn.TestFuzn.Contracts.Sinks;
+using Fuzn.TestFuzn.Internals.Logging;
 using Fuzn.TestFuzn.Internals.State;
 using System.Diagnostics;
 using Fuzn.TestFuzn.Internals.InputData;
@@ -30,9 +31,10 @@ internal class ExecuteScenarioMessageHandler
     }
 
     public async Task Execute(
-        ExecuteScenarioMessage message,
-        Scenario scenario)
+        ExecuteScenarioMessage message)
     {
+        var scenario = message.Scenario;
+
         // Create a new scope for the iteration execution.
         await using var iterationScope = _serviceProvider.CreateAsyncScope();
         var iterationServiceProvider = iterationScope.ServiceProvider;
@@ -41,7 +43,7 @@ internal class ExecuteScenarioMessageHandler
         if (scenario.InputDataInfo.HasInputData)
             currentInputData = _inputDataFeeder.GetNextInput(scenario.Name);
 
-        var iterationState = ContextFactory.CreateIterationState(_testExecutionState.TestSession, iterationServiceProvider, _testExecutionState.TestFramework, scenario, currentInputData, _testExecutionState.CancellationToken);
+        var iterationState = ContextFactory.CreateIterationState(_testExecutionState.TestSession, iterationServiceProvider, _testExecutionState.TestFramework, scenario, currentInputData, message.MessageId, _testExecutionState.CancellationToken);
 
         var iterationResult = new IterationResult();
         iterationResult.CorrelationId = iterationState.Info.CorrelationId;
@@ -61,11 +63,7 @@ internal class ExecuteScenarioMessageHandler
 
             foreach (var (step, index) in scenario.Steps.Select((s,i)=> (s,i)))
             {
-                using var loggingScope = _testExecutionState.TestSession.Logger.BeginScope(new Dictionary<string, object?>
-                {
-                    ["scenario"] = scenario.Name,
-                    ["step"] = index + 1
-                });
+                using var loggingScope = _testExecutionState.TestSession.Logger.BeginScope(new LoggingScopeState(scenario.Name, index + 1));
 
                 await executeStepHandler.ExecuteStep(step);
                 iterationResult.StepResults.Add(executeStepHandler.RootStepResult!.Name, executeStepHandler.RootStepResult);
@@ -134,13 +132,14 @@ internal class ExecuteScenarioMessageHandler
 
             scenarioLoadCollector.RecordMeasurement(executeStepHandler.CurrentScenarioStatus ?? TestStatus.Failed, iterationResult);
 
-            var scenarioLoadResult = scenarioLoadCollector.GetCurrentResult();
+            ScenarioLoadResult scenarioLoadResult = null;
 
             if (scenario.AssertWhileRunningAction != null
                 && _testExecutionState.ExecutionStatus == ExecutionStatus.Running)
             {
                 try
                 {
+                    scenarioLoadResult = scenarioLoadCollector.GetCurrentResult();
                     var context = ContextFactory.CreateScenarioContext(_testExecutionState.TestSession, iterationServiceProvider, _testExecutionState.TestFramework, "AssertWhileRunning", _testExecutionState.CancellationToken);
                     scenario.AssertWhileRunningAction(context, new AssertScenarioStats(scenarioLoadResult));
                 }
@@ -155,7 +154,7 @@ internal class ExecuteScenarioMessageHandler
                 }
             }
 
-            await WriteToSinksAndSnapshotCollector(_testExecutionState, scenario, scenarioLoadResult, false);
+            await WriteToSinksAndSnapshotCollector(_testExecutionState, scenario, () => scenarioLoadResult ?? scenarioLoadCollector.GetCurrentResult(), false);
         }
     }
 
@@ -173,7 +172,7 @@ internal class ExecuteScenarioMessageHandler
 
     public async Task WriteToSinksAndSnapshotCollector(
         TestExecutionState testExecutionState,
-        Scenario scenario, ScenarioLoadResult scenarioLoadResult, 
+        Scenario scenario, Func<ScenarioLoadResult> getScenarioLoadResult,
         bool forceWrite)
     {
         var semaphore = testExecutionState.SinkSemaphores.GetOrAdd(scenario.Name, _ => new SemaphoreSlim(1, 1));
@@ -184,16 +183,18 @@ internal class ExecuteScenarioMessageHandler
             {
                 var now = DateTime.UtcNow;
                 var firstExecution = false;
-                var lastWrite = testExecutionState.LastSinkWrite.GetOrAdd(scenario.Name, 
+                var lastWrite = testExecutionState.LastSinkWrite.GetOrAdd(scenario.Name,
                     (scenarioName) => {
                         firstExecution = true;
-                        return now; 
+                        return now;
                     });
 
                 if (firstExecution
                     || forceWrite
                     || (now - lastWrite).TotalSeconds >= _testExecutionState.TestSession.SinkWriteFrequency.TotalSeconds)
                 {
+                    var scenarioLoadResult = getScenarioLoadResult();
+
                     await testExecutionState.LoadSnapshotCollector.WriteStats(scenarioLoadResult);
 
                     foreach (var sinkPlugin in _sinkPlugins)

--- a/src/TestFuzn/Internals/Execution/ExecuteStepHandler.cs
+++ b/src/TestFuzn/Internals/Execution/ExecuteStepHandler.cs
@@ -23,8 +23,6 @@ internal class ExecuteStepHandler
 
     public async Task ExecuteStep(Step step)
     {
-        step.Validate();
-
         var stepDuration = new Stopwatch();
         stepDuration.Start();
 

--- a/src/TestFuzn/Internals/Execution/Producers/ProducerManager.cs
+++ b/src/TestFuzn/Internals/Execution/Producers/ProducerManager.cs
@@ -38,11 +38,11 @@ internal class ProducerManager
 
             ILoadHandler handler = loadSimulation switch
             {
-                OneTimeLoadConfiguration oneTimeLoad => new OneTimeLoadHandler(oneTimeLoad, scenario.Name, _testExecutionState),
-                FixedConcurrentLoadConfiguration fixedConcurrent => new FixedConcurrentLoadHandler(fixedConcurrent, scenario.Name, _testExecutionState),
-                FixedLoadConfiguration fixedLoad => new FixedLoadHandler(fixedLoad, scenario.Name, _testExecutionState),
-                RandomLoadPerSecondConfiguration randomLoadPerSecond => new RandomLoadPerSecondHandler(randomLoadPerSecond, scenario.Name, _testExecutionState),
-                GradualLoadIncreaseConfiguration gradualLoadIncrease => new GradualLoadIncreaseHandler(gradualLoadIncrease, scenario.Name, _testExecutionState),
+                OneTimeLoadConfiguration oneTimeLoad => new OneTimeLoadHandler(oneTimeLoad, scenario, _testExecutionState),
+                FixedConcurrentLoadConfiguration fixedConcurrent => new FixedConcurrentLoadHandler(fixedConcurrent, scenario, _testExecutionState),
+                FixedLoadConfiguration fixedLoad => new FixedLoadHandler(fixedLoad, scenario, _testExecutionState),
+                RandomLoadPerSecondConfiguration randomLoadPerSecond => new RandomLoadPerSecondHandler(randomLoadPerSecond, scenario, _testExecutionState),
+                GradualLoadIncreaseConfiguration gradualLoadIncrease => new GradualLoadIncreaseHandler(gradualLoadIncrease, scenario, _testExecutionState),
                 PauseLoadConfiguration pauseLoad => new PauseLoadHandler(pauseLoad, _testExecutionState),
                 _ => throw new NotSupportedException($"Load simulation type {loadSimulation.GetType().Name} is not supported."),
             };

--- a/src/TestFuzn/Internals/Execution/Producers/Simulations/FixedConcurrentLoadHandler.cs
+++ b/src/TestFuzn/Internals/Execution/Producers/Simulations/FixedConcurrentLoadHandler.cs
@@ -7,16 +7,16 @@ internal class FixedConcurrentLoadHandler : ILoadHandler
 {
     private readonly FixedConcurrentLoadConfiguration _configuration;
     private readonly TestExecutionState _testExecutionState;
-    private readonly string _scenarioName;
+    private readonly Scenario _scenario;
 
     public FixedConcurrentLoadHandler(
         FixedConcurrentLoadConfiguration configuration,
-        string scenarioName,
+        Scenario scenario,
         TestExecutionState testExecutionState
         )
     {
         _configuration = configuration;
-        _scenarioName = scenarioName;
+        _scenario = scenario;
         _testExecutionState = testExecutionState;
     }
 
@@ -39,7 +39,7 @@ internal class FixedConcurrentLoadHandler : ILoadHandler
                 break;
             }
 
-            var addCount = _configuration.FixedCount - _testExecutionState.GetConstantQueueCount(_scenarioName);
+            var addCount = _configuration.FixedCount - _testExecutionState.GetConstantQueueCount(_scenario.Name);
 
             while (addCount > 0)
             {
@@ -49,7 +49,7 @@ internal class FixedConcurrentLoadHandler : ILoadHandler
                 addCount--;
                 i++;
 
-                var message = new ExecuteScenarioMessage(_scenarioName, _configuration.IsWarmup);
+                var message = new ExecuteScenarioMessage(_scenario, _configuration.IsWarmup);
 
                 _testExecutionState.AddToConstantQueue(message);
                 _testExecutionState.EnqueueScenarioExecution(message);

--- a/src/TestFuzn/Internals/Execution/Producers/Simulations/FixedLoadHandler.cs
+++ b/src/TestFuzn/Internals/Execution/Producers/Simulations/FixedLoadHandler.cs
@@ -6,16 +6,16 @@ namespace Fuzn.TestFuzn.Internals.Execution.Producers.Simulations;
 internal class FixedLoadHandler : ILoadHandler
 {
     private readonly FixedLoadConfiguration _configuration;
-    private readonly string _scenarioName;
+    private readonly Scenario _scenario;
     private readonly TestExecutionState _testExecutionState;
 
     public FixedLoadHandler(
         FixedLoadConfiguration configuration,
-        string scenarioName,
+        Scenario scenario,
         TestExecutionState testExecutionState)
     {
         _configuration = configuration;
-        _scenarioName = scenarioName;
+        _scenario = scenario;
         _testExecutionState = testExecutionState;
     }
 
@@ -44,7 +44,7 @@ internal class FixedLoadHandler : ILoadHandler
                 if (_testExecutionState.ExecutionStatus == ExecutionStatus.Stopped)
                     return;
 
-                var message = new ExecuteScenarioMessage(_scenarioName, _configuration.IsWarmup);
+                var message = new ExecuteScenarioMessage(_scenario, _configuration.IsWarmup);
                 _testExecutionState.EnqueueScenarioExecution(message);
 
                 var nextEnqueueTime = delayBetweenEnqueue.Ticks * (i + 1);

--- a/src/TestFuzn/Internals/Execution/Producers/Simulations/GradualLoadIncreaseHandler.cs
+++ b/src/TestFuzn/Internals/Execution/Producers/Simulations/GradualLoadIncreaseHandler.cs
@@ -5,16 +5,16 @@ namespace Fuzn.TestFuzn.Internals.Execution.Producers.Simulations;
 internal class GradualLoadIncreaseHandler : ILoadHandler
 {
     private readonly GradualLoadIncreaseConfiguration _configuration;
-    private readonly string _scenarioName;
+    private readonly Scenario _scenario;
     private readonly TestExecutionState _testExecutionState;
 
     public GradualLoadIncreaseHandler(
         GradualLoadIncreaseConfiguration configuration,
-        string scenarioName,
+        Scenario scenario,
         TestExecutionState testExecutionState)
     {
         _configuration = configuration;
-        _scenarioName = scenarioName;
+        _scenario = scenario;
         _testExecutionState = testExecutionState;
     }
 
@@ -37,7 +37,7 @@ internal class GradualLoadIncreaseHandler : ILoadHandler
                 if (_testExecutionState.ExecutionStatus == ExecutionStatus.Stopped)
                     return;
 
-                var message = new ExecuteScenarioMessage(_scenarioName, _configuration.IsWarmup);
+                var message = new ExecuteScenarioMessage(_scenario, _configuration.IsWarmup);
 
                 _testExecutionState.EnqueueScenarioExecution(message);
             }

--- a/src/TestFuzn/Internals/Execution/Producers/Simulations/OneTimeLoadHandler.cs
+++ b/src/TestFuzn/Internals/Execution/Producers/Simulations/OneTimeLoadHandler.cs
@@ -5,16 +5,16 @@ namespace Fuzn.TestFuzn.Internals.Execution.Producers.Simulations;
 internal class OneTimeLoadHandler : ILoadHandler
 {
     private readonly OneTimeLoadConfiguration _configuration;
-    private readonly string _scenarioName;
+    private readonly Scenario _scenario;
     private readonly TestExecutionState _testExecutionState;
 
     public OneTimeLoadHandler(
         OneTimeLoadConfiguration configuration,
-        string scenarioName,
+        Scenario scenario,
         TestExecutionState testExecutionState)
     {
         _configuration = configuration;
-        _scenarioName = scenarioName;
+        _scenario = scenario;
         _testExecutionState = testExecutionState;
     }
 
@@ -27,7 +27,7 @@ internal class OneTimeLoadHandler : ILoadHandler
             if (_testExecutionState.ExecutionStatus == ExecutionStatus.Stopped)
                 return Task.CompletedTask;
 
-            var message = new ExecuteScenarioMessage(_scenarioName, _configuration.IsWarmup);
+            var message = new ExecuteScenarioMessage(_scenario, _configuration.IsWarmup);
 
             _testExecutionState.EnqueueScenarioExecution(message);
         }

--- a/src/TestFuzn/Internals/Execution/Producers/Simulations/RandomLoadPerSecondHandler.cs
+++ b/src/TestFuzn/Internals/Execution/Producers/Simulations/RandomLoadPerSecondHandler.cs
@@ -6,16 +6,16 @@ namespace Fuzn.TestFuzn.Internals.Execution.Producers.Simulations;
 internal class RandomLoadPerSecondHandler : ILoadHandler
 {
     private readonly RandomLoadPerSecondConfiguration _configuration;
-    private readonly string _scenarioName;
+    private readonly Scenario _scenario;
     private readonly TestExecutionState _testExecutionState;
 
     public RandomLoadPerSecondHandler(
         RandomLoadPerSecondConfiguration configuration,
-        string scenarioName,
+        Scenario scenario,
         TestExecutionState testExecutionState)
     {
         _configuration = configuration;
-        _scenarioName = scenarioName;
+        _scenario = scenario;
         _testExecutionState = testExecutionState;
     }
 
@@ -41,7 +41,7 @@ internal class RandomLoadPerSecondHandler : ILoadHandler
                 if (_testExecutionState.ExecutionStatus == ExecutionStatus.Stopped)
                     return;
 
-                var message = new ExecuteScenarioMessage(_scenarioName, _configuration.IsWarmup);
+                var message = new ExecuteScenarioMessage(_scenario, _configuration.IsWarmup);
 
                 _testExecutionState.EnqueueScenarioExecution(message);
             }

--- a/src/TestFuzn/Internals/Init/InitManager.cs
+++ b/src/TestFuzn/Internals/Init/InitManager.cs
@@ -44,6 +44,9 @@ internal class InitManager
 
         await SetupSimulations();
 
+        foreach (var scenario in _testExecutionState.Scenarios)
+            _testExecutionState.LoadCollectors[scenario.Name].CacheSimulationDescriptions(scenario);
+
         var timestamp = DateTime.UtcNow;
 
         foreach (var scenario in _testExecutionState.Scenarios)

--- a/src/TestFuzn/Internals/InputData/InputDataFeeder.cs
+++ b/src/TestFuzn/Internals/InputData/InputDataFeeder.cs
@@ -4,7 +4,7 @@ namespace Fuzn.TestFuzn.Internals.InputData;
 
 internal class InputDataFeeder
 {
-    private object _lock = new();
+    private Dictionary<string, object> _locks = new();
     private Dictionary<string, InputEnumeratorInfo> _feeder = new();
     private TestExecutionState _testExecutionState = null!;
 
@@ -20,15 +20,16 @@ internal class InputDataFeeder
                 EndOfInputBehavior = scenario.InputDataInfo.InputDataBehavior,
                 Index = -1
             };
+            _locks[scenario.Name] = new object();
             _feeder[scenario.Name] = enumeratorInfo;
         }
     }
 
     public object GetNextInput(string scenario)
     {
-        lock (_lock)
+        var info = _feeder[scenario];
+        lock (_locks[scenario])
         {
-            var info = _feeder[scenario];
             bool isLastItem = info.Index == info.InputData.Count - 1;
 
             switch (info.EndOfInputBehavior)

--- a/src/TestFuzn/Internals/Logging/FileLogger.cs
+++ b/src/TestFuzn/Internals/Logging/FileLogger.cs
@@ -8,8 +8,6 @@ internal class FileLogger : ILogger
     private readonly StreamWriter _writer;
     private readonly string _categoryName;
     private readonly object _lock;
-    private const int MaxRetryAttempts = 3;
-    private const int RetryDelayMs = 100;
 
     // Thread-safe scope storage using AsyncLocal
     private static readonly AsyncLocal<LoggerScope?> _currentScope = new();
@@ -54,65 +52,37 @@ internal class FileLogger : ILogger
         if (!IsEnabled(logLevel) || formatter == null)
             return;
 
-        int attempt = 0;
-        bool success = false;
-
-        while (!success && attempt < MaxRetryAttempts)
+        try
         {
-            try
+            string message = formatter(state, exception);
+            var (scenario, step) = GetScopeContext();
+            string logRecord = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [{logLevel}] [{scenario}] [Step {step}] {_categoryName} {message}";
+
+            lock (_lock)
             {
-                string message = formatter(state, exception);
-                var (scenario, step) = GetScopeContext();
-                string logRecord = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [{logLevel}] [{scenario}] [Step {step}] {_categoryName} {message}";
+                _writer.WriteLine(logRecord);
 
-                lock (_lock)
+                if (exception != null)
                 {
-                    _writer.WriteLine(logRecord);
+                    _writer.WriteLine($"Exception: {exception.Message}");
+                    _writer.WriteLine($"StackTrace: {exception.StackTrace}");
 
-                    if (exception != null)
+                    var innerException = exception.InnerException;
+                    while (innerException != null)
                     {
-                        _writer.WriteLine($"Exception: {exception.Message}");
-                        _writer.WriteLine($"StackTrace: {exception.StackTrace}");
-
-                        var innerException = exception.InnerException;
-                        while (innerException != null)
-                        {
-                            _writer.WriteLine($"Inner Exception: {innerException.Message}");
-                            innerException = innerException.InnerException;
-                        }
+                        _writer.WriteLine($"Inner Exception: {innerException.Message}");
+                        innerException = innerException.InnerException;
                     }
-
-                    _writer.Flush();
-                    success = true;
                 }
             }
-            catch (IOException)
-            {
-                // File might be locked, retry after delay
-                attempt++;
-                if (attempt < MaxRetryAttempts)
-                {
-                    Thread.Sleep(RetryDelayMs);
-                }
-                else
-                {
-                    // Log to console if all retries fail
-                    Console.Error.WriteLine($"Failed to write to log after {MaxRetryAttempts} attempts: [{logLevel}] {_categoryName}");
-                }
-            }
-            catch (ObjectDisposedException)
-            {
-                // Writer was disposed, log to console
-                Console.Error.WriteLine($"Cannot write to log - writer was disposed: [{logLevel}] {_categoryName}");
-                break;
-            }
-            catch (Exception ex)
-            {
-                // Unexpected error, log to console
-                Console.Error.WriteLine($"Unexpected error during logging: {ex.Message}");
-                Console.Error.WriteLine(ex.StackTrace);
-                break;
-            }
+        }
+        catch (ObjectDisposedException)
+        {
+            Console.Error.WriteLine($"Cannot write to log - writer was disposed: [{logLevel}] {_categoryName}");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unexpected error during logging: {ex.Message}");
         }
     }
 
@@ -125,28 +95,16 @@ internal class FileLogger : ILogger
         if (scope == null)
             return (string.Empty, string.Empty);
 
-        string? scenario = null;
-        string? step = null;
-
-        // Walk the scope chain to find scenario and step values
+        // Fast path: check for LoggingScopeState to avoid dictionary allocations
         while (scope != null)
         {
-            var scopeValues = scope.GetScopeValues();
-            
-            if (scenario == null && scopeValues.TryGetValue("scenario", out var scenarioValue))
-                scenario = scenarioValue?.ToString();
-            
-            if (step == null && scopeValues.TryGetValue("step", out var stepValue))
-                step = stepValue?.ToString();
-            
-            // If we found both, no need to continue
-            if (scenario != null && step != null)
-                break;
-            
+            if (scope.State is LoggingScopeState scopeState)
+                return (scopeState.Scenario, scopeState.Step.ToString());
+
             scope = scope.Parent;
         }
 
-        return (scenario ?? string.Empty, step ?? string.Empty);
+        return (string.Empty, string.Empty);
     }
 
     /// <summary>
@@ -159,33 +117,12 @@ internal class FileLogger : ILogger
         private bool _disposed;
 
         public LoggerScope? Parent => _parent;
+        public object State => _state;
 
         public LoggerScope(object state, LoggerScope? parent)
         {
             _state = state;
             _parent = parent;
-        }
-
-        /// <summary>
-        /// Gets scope values as a dictionary
-        /// </summary>
-        public Dictionary<string, object?> GetScopeValues()
-        {
-            var values = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-
-            if (_state == null)
-                return values;
-
-            // Handle Dictionary<string, object?> which is commonly used for structured scopes
-            if (_state is IEnumerable<KeyValuePair<string, object?>> kvps)
-            {
-                foreach (var kvp in kvps)
-                {
-                    values[kvp.Key] = kvp.Value;
-                }
-            }
-
-            return values;
         }
 
         public void Dispose()

--- a/src/TestFuzn/Internals/Logging/FileLoggerProvider.cs
+++ b/src/TestFuzn/Internals/Logging/FileLoggerProvider.cs
@@ -11,8 +11,6 @@ internal class FileLoggerProvider : ILoggerProvider, IDisposable
     private readonly StreamWriter _writer;
     private readonly object _lock = new object();
     private bool _disposed;
-    private const int MaxRetryAttempts = 3;
-    private const int RetryDelayMs = 100;
 
     /// <summary>
     /// Initializes a new instance of the FileLoggerProvider
@@ -72,41 +70,19 @@ internal class FileLoggerProvider : ILoggerProvider, IDisposable
     /// </summary>
     private void WriteDirectly(string message)
     {
-        int attempt = 0;
-        bool success = false;
-
-        while (!success && attempt < MaxRetryAttempts)
+        try
         {
-            try
+            lock (_lock)
             {
-                lock (_lock)
+                if (!_disposed)
                 {
-                    if (!_disposed)
-                    {
-                        _writer.WriteLine(message);
-                        _writer.Flush();
-                        success = true;
-                    }
+                    _writer.WriteLine(message);
                 }
             }
-            catch (IOException)
-            {
-                // File might be temporarily locked, retry after delay
-                attempt++;
-                if (attempt < MaxRetryAttempts)
-                {
-                    Thread.Sleep(RetryDelayMs);
-                }
-                else
-                {
-                    Console.Error.WriteLine($"Failed to write to log file after {MaxRetryAttempts} attempts: {message}");
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"Unexpected error writing to log file: {ex.Message}");
-                break;
-            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Unexpected error writing to log file: {ex.Message}");
         }
     }
 
@@ -132,7 +108,6 @@ internal class FileLoggerProvider : ILoggerProvider, IDisposable
                 {
                     lock (_lock)
                     {
-                        _writer.Flush();
                         _writer.Dispose();
                     }
                 }

--- a/src/TestFuzn/Internals/Logging/LoggingScopeState.cs
+++ b/src/TestFuzn/Internals/Logging/LoggingScopeState.cs
@@ -1,0 +1,16 @@
+namespace Fuzn.TestFuzn.Internals.Logging;
+
+/// <summary>
+/// Lightweight scope state for scenario/step context, avoiding dictionary allocations in the hot path.
+/// </summary>
+internal readonly struct LoggingScopeState
+{
+    public string Scenario { get; }
+    public int Step { get; }
+
+    public LoggingScopeState(string scenario, int step)
+    {
+        Scenario = scenario;
+        Step = step;
+    }
+}

--- a/src/TestFuzn/Internals/Results/Load/ScenarioLoadCollector.cs
+++ b/src/TestFuzn/Internals/Results/Load/ScenarioLoadCollector.cs
@@ -32,7 +32,7 @@ internal class ScenarioLoadCollector
     private Exception _assertWhileWarmingUpException;
     private Exception _assertWhileRunningException;
     private Exception _assertWhenDoneException;
-    private Scenario _scenario;
+    private List<string> _simulationDescriptions;
 
     public string ScenarioName { get => _scenarioName; set => _scenarioName = value; }
     public string Id { get => _id; set => _id = value; }
@@ -47,7 +47,15 @@ internal class ScenarioLoadCollector
         {
             _steps.Add(step.Name, new StepLoadCollector(step.Name, step.Id));
         }
-        _scenario = scenario;
+    }
+
+    internal void CacheSimulationDescriptions(Scenario scenario)
+    {
+        _simulationDescriptions = new List<string>();
+        foreach (var simulation in scenario.SimulationsInternal)
+        {
+            _simulationDescriptions.Add(simulation.GetDescription());
+        }
     }
 
     internal void RecordWarmup(TestStatus status)
@@ -179,11 +187,7 @@ internal class ScenarioLoadCollector
             result.Id = _id;
             result.Description = _description;
 
-            result.Simulations = new List<string>();
-            foreach (var simulation in _scenario.SimulationsInternal)
-            {
-                result.Simulations.Add(simulation.GetDescription());
-            }
+            result.Simulations = _simulationDescriptions;
             result.InitStartTime = _initStartTime;
             result.InitEndTime = _initEndTime;
             // Warmup phase.

--- a/src/TestFuzn/ScenarioBuilder.cs
+++ b/src/TestFuzn/ScenarioBuilder.cs
@@ -184,6 +184,7 @@ public class ScenarioBuilder<TModel>
         step.Name = name;
         step.Id = id;
         step.Action = context => action((IterationContext<TModel>) context);
+        step.Validate();
         Scenario.Steps.Add(step);
 
         return this;

--- a/src/TestWebApp/Dockerfile
+++ b/src/TestWebApp/Dockerfile
@@ -13,19 +13,19 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
-COPY ["SampleApp.WebApp/SampleApp.WebApp.csproj", "SampleApp.WebApp/"]
-RUN dotnet restore "./SampleApp.WebApp/SampleApp.WebApp.csproj"
+COPY ["TestWebApp/TestWebApp.csproj", "TestWebApp/"]
+RUN dotnet restore "./TestWebApp/TestWebApp.csproj"
 COPY . .
-WORKDIR "/src/SampleApp.WebApp"
-RUN dotnet build "./SampleApp.WebApp.csproj" -c $BUILD_CONFIGURATION -o /app/build
+WORKDIR "/src/TestWebApp"
+RUN dotnet build "./TestWebApp.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./SampleApp.WebApp.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./TestWebApp.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "SampleApp.WebApp.dll"]
+ENTRYPOINT ["dotnet", "TestWebApp.dll"]

--- a/src/TestWebApp/Properties/launchSettings.json
+++ b/src/TestWebApp/Properties/launchSettings.json
@@ -8,6 +8,16 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:7058;http://localhost:7059"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_HTTPS_PORTS": "8081"
+      },
+      "publishAllPorts": true,
+      "useSSL": true
     }
   }
 }

--- a/src/docker-compose.dcproj
+++ b/src/docker-compose.dcproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" Sdk="Microsoft.Docker.Sdk">
+  <PropertyGroup Label="Globals">
+    <ProjectVersion>2.1</ProjectVersion>
+    <DockerTargetOS>Linux</DockerTargetOS>
+    <DockerPublishLocationType>Registry</DockerPublishLocationType>
+    <ProjectGuid>b1f4e39a-7c2d-4d8e-9f5a-3c6b8d0e1f2a</ProjectGuid>
+    <DockerLaunchAction>LaunchBrowser</DockerLaunchAction>
+    <DockerServiceUrl>{Scheme}://localhost:{ServicePort}/swagger</DockerServiceUrl>
+    <DockerServiceName>testwebapp</DockerServiceName>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="docker-compose.override.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.yml" />
+  </ItemGroup>
+</Project>

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -1,0 +1,26 @@
+services:
+  testwebapp:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_HTTP_PORTS=
+      - ASPNETCORE_HTTPS_PORTS=8081
+      - ASPNETCORE_Kestrel__Certificates__Default__Password=devcert
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=/home/app/.aspnet/https/TestWebApp.pfx
+    ports:
+      - "7058:8081"
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
+      - ${APPDATA}/ASP.NET/Https:/home/app/.aspnet/https:ro
+
+  sampleapp.webapp:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_HTTP_PORTS=8080
+      - ASPNETCORE_HTTPS_PORTS=8081
+      - ASPNETCORE_Kestrel__Certificates__Default__Password=devcert
+      - ASPNETCORE_Kestrel__Certificates__Default__Path=/home/app/.aspnet/https/SampleApp.WebApp.pfx
+    ports:
+      - "44316:8081"
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
+      - ${APPDATA}/ASP.NET/Https:/home/app/.aspnet/https:ro

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  testwebapp:
+    image: ${DOCKER_REGISTRY-}testwebapp
+    build:
+      context: .
+      dockerfile: TestWebApp/Dockerfile
+
+  sampleapp.webapp:
+    image: ${DOCKER_REGISTRY-}sampleappwebapp
+    build:
+      context: .
+      dockerfile: SampleApp.WebApp/Dockerfile
+
+  influxdb:
+    image: influxdb:2.7
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb2_data:/var/lib/influxdb2
+      - influxdb2_config:/etc/influxdb2
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: admin123
+      DOCKER_INFLUXDB_INIT_ORG: DefaultOrg
+      DOCKER_INFLUXDB_INIT_BUCKET: TestFuzn
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: default_admin_token
+
+  grafana:
+    image: grafana/grafana:latest
+    profiles:
+      - monitoring
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./TestFuzn.Tests.Runner/provisioning/dashboards.yml:/etc/grafana/provisioning/dashboards/main.yaml
+      - ./TestFuzn.Tests.Runner/provisioning/dashboards:/var/lib/grafana/dashboards
+      - ./TestFuzn.Tests.Runner/provisioning/datasources:/etc/grafana/provisioning/datasources
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - influxdb
+
+volumes:
+  influxdb2_data:
+  influxdb2_config:


### PR DESCRIPTION
Reduce per-iteration overhead in the load test execution pipeline:
- Replace Activator.CreateInstance with cached compiled expressions in ContextFactory
- Pass Scenario object through ExecuteScenarioMessage to avoid repeated LINQ lookups
- Lazily evaluate ScenarioLoadResult via Func<> to skip unnecessary computation
- Cache simulation descriptions instead of regenerating on every result snapshot
- Use per-scenario locks in InputDataFeeder instead of a single global lock
- Set MaxDegreeOfParallelism to unbounded for consumer parallelism
- Move step validation from execution to build time (validate once)
- Use message ID as correlation ID instead of allocating new GUIDs

Simplify logging internals:
- Add LoggingScopeState struct to avoid dictionary allocations in the hot path
- Remove retry/flush logic from FileLogger and FileLoggerProvider

Add docker-compose setup for TestWebApp, SampleApp, InfluxDB, and Grafana